### PR TITLE
bump up nlopes/slack, support of rich_text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/nlopes/slack v0.6.0
+	github.com/nlopes/slack v0.6.1-0.20191102190149-d20eeb27bf8f
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cast v1.3.0


### PR DESCRIPTION
support rich_text (workaround). 

ref: https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less