### PR TITLE
refactoring: remove deprecated methods

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.13
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          version: 1.13
+          version: 1.15
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/whywaita/aguri
 
-go 1.14
+go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
-	github.com/slack-go/slack v0.6.4
+	github.com/slack-go/slack v0.8.1
 	github.com/spf13/cast v1.3.1
-	github.com/whywaita/slack_lib v0.2.0
 	github.com/whywaita/slackrus v0.1.0
 )

--- a/pkg/reply/commands.go
+++ b/pkg/reply/commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/whywaita/aguri/pkg/config"
 	"github.com/whywaita/aguri/pkg/store"
 	"github.com/whywaita/aguri/pkg/utils"
-	"github.com/whywaita/slack_lib"
 )
 
 const (
@@ -172,7 +171,7 @@ func CommandGetHistory(workspace, channel string, limit int) error {
 		m := resp.Messages[len(resp.Messages)-i]
 
 		if m.User != "" {
-			username, _, err := slack_lib.ConvertDisplayUserName(fromAPI, nil, m.User) // set user id, do not use ev
+			username, _, err := utils.ConvertDisplayUserName(fromAPI, nil, m.User) // set user id, do not use ev
 			if err != nil {
 				return errors.Wrap(err, "failed to get history")
 			}

--- a/pkg/reply/commands.go
+++ b/pkg/reply/commands.go
@@ -89,9 +89,9 @@ func CommandList(workspace, target string) error {
 	}
 
 	api := store.GetSlackApiInstance(workspace)
-	channels, err := api.GetChannels(true)
+	channels, err := utils.GetAllConversations(api)
 	if err != nil {
-		return errors.Wrap(err, "failed to get channels")
+		return errors.Wrap(err, "failed to get all conversations")
 	}
 
 	var joinedChannels []string

--- a/pkg/reply/reply.go
+++ b/pkg/reply/reply.go
@@ -6,12 +6,13 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/whywaita/aguri/pkg/utils"
+
 	"github.com/pkg/errors"
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackutilsx"
 	"github.com/whywaita/aguri/pkg/config"
 	"github.com/whywaita/aguri/pkg/store"
-	"github.com/whywaita/slack_lib"
 )
 
 var (
@@ -57,7 +58,7 @@ func HandleReplyMessage(loggerMap *store.SyncLoggerMap) {
 	for msg := range rtm.IncomingEvents {
 		switch ev := msg.Data.(type) {
 		case *slack.MessageEvent:
-			fromType, aggrChName, err := slack_lib.ConvertDisplayChannelName(toAPI, ev)
+			fromType, aggrChName, err := utils.ConvertDisplayChannelName(toAPI, ev)
 			if err != nil {
 				log.Println(err)
 				break

--- a/pkg/utils/convert.go
+++ b/pkg/utils/convert.go
@@ -91,7 +91,7 @@ func ConvertDisplayChannelName(api *slack.Client, ev *slack.MessageEvent) (fromT
 	fromType = channelType.String()
 	switch channelType {
 	case slackutilsx.CTypeChannel:
-		info, err := api.GetChannelInfo(ev.Channel)
+		info, err := api.GetConversationInfo(ev.Channel, false)
 		if err != nil {
 			if err.Error() == ErrMethodNotSupportedForChannelType {
 				// This error occurred by the private channels only converted from the public channel.
@@ -110,7 +110,7 @@ func ConvertDisplayChannelName(api *slack.Client, ev *slack.MessageEvent) (fromT
 		return fromType, info.Name, nil
 
 	case slackutilsx.CTypeGroup:
-		info, err := api.GetGroupInfo(ev.Channel)
+		info, err := api.GetConversationInfo(ev.Channel, false)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/utils/convert.go
+++ b/pkg/utils/convert.go
@@ -1,0 +1,175 @@
+package utils
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackutilsx"
+)
+
+const (
+	ErrMethodNotSupportedForChannelType = "method_not_supported_for_channel_type"
+)
+
+func GetConversationsList(api *slack.Client, types []slackutilsx.ChannelType) ([]slack.Channel, error) {
+	var paramTypes []string
+
+	for _, t := range types {
+		switch t {
+		case slackutilsx.CTypeChannel:
+			paramTypes = append(paramTypes, "public_channel")
+		case slackutilsx.CTypeGroup:
+			paramTypes = append(paramTypes, "private_channel")
+		case slackutilsx.CTypeDM:
+			paramTypes = append(paramTypes, "im")
+		default:
+			paramTypes = append(paramTypes, "")
+		}
+	}
+
+	param := &slack.GetConversationsParameters{
+		ExcludeArchived: "true",
+		Types:           paramTypes,
+	}
+
+	channels, nextCursor, err := api.GetConversations(param)
+	if err != nil {
+		return nil, err
+	}
+
+	for nextCursor != "" {
+		param = &slack.GetConversationsParameters{
+			ExcludeArchived: "true",
+			Types:           paramTypes,
+			Cursor:          nextCursor,
+		}
+		c, n, err := api.GetConversations(param)
+		if err != nil {
+			return nil, err
+		}
+		channels = Concat(channels, c)
+		nextCursor = n
+	}
+
+	return channels, nil
+}
+
+func Concat(xs, ys []slack.Channel) []slack.Channel {
+	zs := make([]slack.Channel, len(xs)+len(ys))
+
+	for i, x := range xs {
+		zs[i] = x
+	}
+
+	l := len(xs)
+	for j, y := range ys {
+		zs[l+j] = y
+	}
+
+	return zs
+}
+
+func ConvertDisplayPrivateChannel(api *slack.Client, channelId string) (string, error) {
+	channels, err := GetConversationsList(api, []slackutilsx.ChannelType{slackutilsx.CTypeGroup})
+	if err != nil {
+		return "", err
+	}
+
+	for _, c := range channels {
+		if c.ID == channelId {
+			return c.Name, nil
+		}
+	}
+
+	return "", errors.New("channel not found")
+}
+
+func ConvertDisplayChannelName(api *slack.Client, ev *slack.MessageEvent) (fromType, name string, err error) {
+	// identify channel or group (as known as private channel) or DM
+
+	channelType := slackutilsx.DetectChannelType(ev.Channel)
+	fromType = channelType.String()
+	switch channelType {
+	case slackutilsx.CTypeChannel:
+		info, err := api.GetChannelInfo(ev.Channel)
+		if err != nil {
+			if err.Error() == ErrMethodNotSupportedForChannelType {
+				// This error occurred by the private channels only converted from the public channel.
+				// So, this is private channel if this error.
+				name, err := ConvertDisplayPrivateChannel(api, ev.Channel)
+				if err != nil {
+					return "", "", err
+				}
+
+				return fromType, name, nil
+			} else {
+				return "", "", err
+			}
+		}
+
+		return fromType, info.Name, nil
+
+	case slackutilsx.CTypeGroup:
+		info, err := api.GetGroupInfo(ev.Channel)
+		if err != nil {
+			return "", "", err
+		}
+
+		return fromType, info.Name, nil
+
+	case slackutilsx.CTypeDM:
+		if ev.Msg.SubType != "" {
+			// SubType is not define user
+		} else {
+			info, err := api.GetUserInfo(ev.Msg.User)
+			if err != nil {
+				return "", "", err
+			}
+
+			return fromType, info.Name, nil
+		}
+	default:
+		name = ""
+	}
+
+	return "", "", errors.New("channel not found")
+}
+
+func ConvertDisplayUserName(api *slack.Client, ev *slack.MessageEvent, id string) (username, usertype string, err error) {
+	// user id to display name
+
+	if id != "" {
+		// specific id (maybe user)
+		info, err := api.GetUserInfo(id)
+		if err != nil {
+			return "", "", err
+		}
+
+		return info.Name, "user", nil
+	}
+
+	// return self id
+	if ev.Msg.BotID == "B01" {
+		// this is slackbot
+		return "Slack bot", "bot", nil
+	} else if ev.Msg.BotID != "" {
+		// this is bot
+		byInfo, err := api.GetBotInfo(ev.Msg.BotID)
+		if err != nil {
+			return "", "", err
+		}
+
+		return byInfo.Name, "bot", nil
+	} else if ev.Msg.SubType != "" {
+		// SubType is not define user
+		return ev.Msg.SubType, "status", nil
+	} else {
+		// user
+		byInfo, err := api.GetUserInfo(ev.Msg.User)
+		if err != nil {
+			return "", "", err
+		}
+
+		return byInfo.Name, "user", nil
+	}
+}

--- a/pkg/utils/message.go
+++ b/pkg/utils/message.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jinzhu/copier"
+	"github.com/slack-go/slack"
+)
+
+func ConvertUnixToTime(inputTS string) (string, error) {
+	// convert unixtime to Time
+	times := strings.Split(inputTS, ".")
+	unixtime := times[0]
+	intTS, err := strconv.ParseInt(unixtime, 10, 64)
+	if err != nil {
+		return "", err
+	}
+
+	ts := time.Unix(intTS, 0).String()
+
+	return ts, nil
+}
+
+func ConvertReadableName(api *slack.Client, ev *slack.MessageEvent) (slack.Msg, error) {
+	var err error
+
+	result := slack.Msg{}
+	msg := ev.Msg
+
+	copier.Copy(&result, &msg)
+
+	// convert ID to Name
+	rUser, err := api.GetUserInfo(msg.User)
+	if err != nil {
+		return slack.Msg{}, err
+	}
+
+	_, channelName, err := ConvertDisplayChannelName(api, ev)
+	if err != nil {
+		return slack.Msg{}, err
+	}
+
+	rTeam, err := api.GetTeamInfo()
+	if err != nil {
+		return slack.Msg{}, err
+	}
+
+	if err != nil {
+		return slack.Msg{}, err
+	}
+
+	// convert time
+	ts, err := ConvertUnixToTime(msg.Timestamp)
+	if err != nil {
+		return slack.Msg{}, err
+	}
+
+	result.User = rUser.Name
+	result.Channel = channelName
+	result.Team = rTeam.Name
+	result.Timestamp = ts
+
+	return result, nil
+}

--- a/pkg/utils/slack.go
+++ b/pkg/utils/slack.go
@@ -180,3 +180,29 @@ func PostMessageToChannel(toAPI, fromAPI *slack.Client, ev *slack.MessageEvent, 
 func GenerateAguriUsername(msg *slack.Message, ch *slack.Channel, displayUsername string) string {
 	return displayUsername + "@" + strings.ToLower(ch.ID[:1]) + ":" + ch.Name
 }
+
+func GetAllConversations(api *slack.Client) ([]slack.Channel, error) {
+	params := &slack.GetConversationsParameters{
+		Cursor:          "",
+		ExcludeArchived: "true",
+		Limit:           0,
+		Types:           nil,
+	}
+
+	var channels []slack.Channel
+
+	for {
+		chs, cursor, err := api.GetConversations(params)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get channels")
+		}
+		channels = append(channels, chs...)
+
+		if cursor == "" {
+			break
+		}
+		params.Cursor = cursor
+	}
+
+	return channels, nil
+}

--- a/pkg/utils/slack.go
+++ b/pkg/utils/slack.go
@@ -9,7 +9,6 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/whywaita/aguri/pkg/config"
 	"github.com/whywaita/aguri/pkg/store"
-	"github.com/whywaita/slack_lib"
 )
 
 var (
@@ -92,7 +91,7 @@ func ConvertId2NameInMsg(msg string, ev *slack.MessageEvent, fromAPI *slack.Clie
 		for _, ids := range userIds {
 			id := strings.TrimPrefix(ids[0], "<@")
 			id = strings.TrimSuffix(id, ">")
-			name, _, err := slack_lib.ConvertDisplayUserName(fromAPI, ev, id)
+			name, _, err := ConvertDisplayUserName(fromAPI, ev, id)
 			if err != nil {
 				return "", err
 			}
@@ -105,7 +104,7 @@ func ConvertId2NameInMsg(msg string, ev *slack.MessageEvent, fromAPI *slack.Clie
 
 func GetUserInfo(fromAPI *slack.Client, ev *slack.MessageEvent) (username, icon string, err error) {
 	// get source username and channel, im, group
-	user, usertype, err := slack_lib.ConvertDisplayUserName(fromAPI, ev, "")
+	user, usertype, err := ConvertDisplayUserName(fromAPI, ev, "")
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to convert display name")
 	}
@@ -136,7 +135,7 @@ func PostMessageToChannel(toAPI, fromAPI *slack.Client, ev *slack.MessageEvent, 
 	}
 
 	user, icon, err := GetUserInfo(fromAPI, ev)
-	fType, position, err := slack_lib.ConvertDisplayChannelName(fromAPI, ev)
+	fType, position, err := ConvertDisplayChannelName(fromAPI, ev)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert channel name")
 	}


### PR DESCRIPTION
ref: [Deprecating early methods in favor of the Conversations API](https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api)